### PR TITLE
Add four-bar linkage simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # Chrono_data
+
+This repository contains utilities for mechanism kinematics.
+
+## Four-bar linkage solver
+
+`four_bar.py` provides a function `four_bar_angles` that computes the coupler and rocker angles of a planar four-bar linkage for a given set of link lengths and input crank angle. The solver uses purely geometric methods and only relies on the Python standard library.
+
+Run the demo from the command line:
+
+```bash
+python3 four_bar.py
+```
+
+## Four-bar linkage simulation
+
+`chrono_four_bar.py` builds the same mechanism using the PyChrono physics
+engine. The script requires the PyChrono Python bindings, which must be
+installed separately. During the simulation it prints the instantaneous
+angles of the moving links.
+
+```bash
+python3 chrono_four_bar.py
+```

--- a/chrono_four_bar.py
+++ b/chrono_four_bar.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""PyChrono simulation of a four-bar linkage.
+
+This script builds a planar four-bar mechanism and runs a simple
+dynamic simulation using the PyChrono physics engine. The mechanism
+geometry matches the example used in ``four_bar.py``.
+
+Because visualization libraries are not included, the script prints
+angles of each link during the simulation instead of rendering a
+window.
+"""
+import math
+
+# PyChrono is typically imported as ``import pychrono as chrono``.
+# The package is large and may require manual installation from
+# https://github.com/projectchrono/chrono.
+try:
+    import pychrono as chrono
+except ImportError as exc:  # pragma: no cover - optional dependency
+    raise SystemExit("PyChrono is required to run this script") from exc
+
+from four_bar import four_bar_angles
+
+# Link lengths used in the example
+L1, L2, L3, L4 = 4.0, 3.0, 5.0, 4.0
+
+
+def build_four_bar(theta2=math.radians(30)):
+    """Create a Chrono system with a four-bar mechanism."""
+    system = chrono.ChSystemNSC()
+
+    # Compute initial configuration of the coupler and rocker
+    theta3, theta4 = four_bar_angles(L1, L2, L3, L4, theta2)
+    xb = L2 * math.cos(theta2)
+    yb = L2 * math.sin(theta2)
+    xc = xb + L3 * math.cos(theta3)
+    yc = yb + L3 * math.sin(theta3)
+
+    # Ground body
+    ground = chrono.ChBody()
+    ground.SetBodyFixed(True)
+    ground.SetCollide(False)
+    system.Add(ground)
+
+    # Helper for slender links aligned with the x-axis
+    def make_link(length, angle, cx, cy):
+        body = chrono.ChBodyEasyBox(length, 0.1, 0.1, 1.0, True, True)
+        body.SetPos(chrono.ChVectorD(cx, cy, 0))
+        body.SetRot(chrono.Q_from_AngZ(angle))
+        body.SetCollide(False)
+        system.Add(body)
+        return body
+
+    # Create links at the computed positions
+    crank = make_link(L2, theta2, xb / 2, yb / 2)
+    coupler = make_link(L3, theta3, (xb + xc) / 2, (yb + yc) / 2)
+    rocker = make_link(L4, theta4, (xc + L1) / 2, yc / 2)
+
+    # Revolute joints
+    def rev(body1, body2, x, y):
+        joint = chrono.ChLinkLockRevolute()
+        joint.Initialize(body1, body2,
+                         chrono.ChCoordsysD(chrono.ChVectorD(x, y, 0)))
+        system.Add(joint)
+
+    rev(crank, ground, 0, 0)
+    rev(coupler, crank, xb, yb)
+    rev(rocker, coupler, xc, yc)
+    rev(rocker, ground, L1, 0)
+
+    # Drive the crank with a constant angular speed motor
+    motor = chrono.ChLinkMotorRotationSpeed()
+    motor.Initialize(crank, ground,
+                     chrono.ChFrameD(chrono.ChVectorD(0, 0, 0)))
+    motor.SetSpeedFunction(chrono.ChFunction_Const(math.radians(30)))
+    system.Add(motor)
+
+    return system, crank, coupler, rocker
+
+
+def simulate(duration=1.0, step=1e-3):
+    """Run the simulation and print link angles."""
+    system, crank, coupler, rocker = build_four_bar()
+    while system.GetChTime() < duration:
+        system.DoStepDynamics(step)
+        t = system.GetChTime()
+        a2 = chrono.Q_to_Euler123(crank.GetRot()).z
+        a3 = chrono.Q_to_Euler123(coupler.GetRot()).z
+        a4 = chrono.Q_to_Euler123(rocker.GetRot()).z
+        print(
+            f"{t:.3f} {math.degrees(a2):.2f} "
+            f"{math.degrees(a3):.2f} {math.degrees(a4):.2f}"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    simulate()

--- a/four_bar.py
+++ b/four_bar.py
@@ -1,0 +1,87 @@
+import math
+from typing import Tuple
+
+
+def _circle_intersections(x0: float, y0: float, r0: float,
+                          x1: float, y1: float, r1: float):
+    """Return intersection points of two circles.
+
+    Returns a tuple of two points (x, y) for the intersections. If no
+    intersection exists, returns None.
+    """
+    dx = x1 - x0
+    dy = y1 - y0
+    d = math.hypot(dx, dy)
+    # no solution cases
+    if d > r0 + r1 or d < abs(r0 - r1) or d == 0:
+        return None
+    a = (r0**2 - r1**2 + d**2) / (2 * d)
+    h_sq = r0**2 - a**2
+    if h_sq < 0:
+        # numerical rounding
+        h_sq = 0.0
+    h = math.sqrt(h_sq)
+    xm = x0 + a * dx / d
+    ym = y0 + a * dy / d
+    rx = -dy * (h / d)
+    ry = dx * (h / d)
+    p1 = (xm + rx, ym + ry)
+    p2 = (xm - rx, ym - ry)
+    return p1, p2
+
+
+def four_bar_angles(l1: float, l2: float, l3: float, l4: float,
+                    theta2: float, elbow: str = 'open') -> Tuple[float, float]:
+    """Solve a planar four-bar linkage.
+
+    Parameters
+    ----------
+    l1 : float
+        Ground link length.
+    l2 : float
+        Input crank length.
+    l3 : float
+        Coupler link length.
+    l4 : float
+        Output rocker length.
+    theta2 : float
+        Input crank angle in radians.
+    elbow : str, optional
+        Configuration, either ``'open'`` or ``'cross'``.
+
+    Returns
+    -------
+    (theta3, theta4) : Tuple[float, float]
+        Coupler and rocker angles in radians.
+
+    Raises
+    ------
+    ValueError
+        If the mechanism cannot be assembled with the given geometry.
+    """
+    x_b = l2 * math.cos(theta2)
+    y_b = l2 * math.sin(theta2)
+    intersection = _circle_intersections(x_b, y_b, l3, l1, 0.0, l4)
+    if intersection is None:
+        raise ValueError('No solution for given geometry and input angle')
+    if elbow == 'open':
+        x_c, y_c = max(intersection, key=lambda p: p[1])
+    else:
+        x_c, y_c = min(intersection, key=lambda p: p[1])
+    theta3 = math.atan2(y_c - y_b, x_c - x_b)
+    theta4 = math.atan2(y_c, x_c - l1)
+    return theta3, theta4
+
+
+def demo():
+    """Demonstrate solving a four-bar linkage."""
+    # example lengths and input angle
+    l1, l2, l3, l4 = 4.0, 3.0, 5.0, 4.0
+    theta2 = math.radians(30)
+    t3, t4 = four_bar_angles(l1, l2, l3, l4, theta2)
+    print(f"Theta3: {math.degrees(t3):.2f} deg")
+    print(f"Theta4: {math.degrees(t4):.2f} deg")
+
+
+if __name__ == '__main__':
+    demo()

--- a/test_four_bar.py
+++ b/test_four_bar.py
@@ -1,0 +1,29 @@
+import math
+import unittest
+from four_bar import four_bar_angles
+
+
+class FourBarTest(unittest.TestCase):
+    def test_geometry_closure(self):
+        l1, l2, l3, l4 = 4.0, 3.0, 5.0, 4.0
+        theta2 = math.radians(30)
+        theta3, theta4 = four_bar_angles(l1, l2, l3, l4, theta2)
+
+        # position of B
+        x_b = l2 * math.cos(theta2)
+        y_b = l2 * math.sin(theta2)
+
+        # position of C from coupler
+        x_c1 = x_b + l3 * math.cos(theta3)
+        y_c1 = y_b + l3 * math.sin(theta3)
+
+        # position of C from rocker
+        x_c2 = l1 + l4 * math.cos(theta4)
+        y_c2 = l4 * math.sin(theta4)
+
+        self.assertAlmostEqual(x_c1, x_c2, places=7)
+        self.assertAlmostEqual(y_c1, y_c2, places=7)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend README with PyChrono simulation instructions
- add chrono_four_bar.py example that builds and runs a four-bar linkage in PyChrono
- implement geometric solver four_bar.py
- add basic unit test
- fix style issues after running flake8

## Testing
- `flake8 .`
- `python3 -m unittest -v`


------
https://chatgpt.com/codex/tasks/task_e_6881923ea88c832cb06d0206d92d2e3a